### PR TITLE
Added Aaron Swartz as Markdown collaborator

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
                     <a id="created" class="anchor" href="#what"></a>Who created Markdown?
                 </h2>                    
                 <p>
-                    It was <a href="https://en.wikipedia.org/wiki/Markdown#History">developed in 2004 by John Gruber</a>, who wrote the first markdown-to-html converter in Perl, and it soon became widely used in websites. By 2014 there were dozens of implementations in many languages.
+                    It was <a href="https://en.wikipedia.org/wiki/Markdown#History">developed in 2004 by John Gruber in collaboration with Aaron Swartz</a>. Gruber wrote the first markdown-to-html converter in Perl, and it soon became widely used in websites. By 2014 there were dozens of implementations in many languages.
                 </p>
 
                 <h2>


### PR DESCRIPTION
This pull request addresses issue #21. The [Wikipedia page that describes Markdown's history](https://en.wikipedia.org/wiki/Markdown#History) credits Aaron Swartz as a collaborator, so the CommonMark homepage that links to it should as well.